### PR TITLE
Dcument the 4dn-status protocol (C4-509)

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -1,0 +1,65 @@
+=======================
+Testing a brig function
+=======================
+
+This document describes various ways to test this repository.
+
+
+Set Up a Virtual Environment
+============================
+
+**Before testing** make sure you have built a virtual environment in the toplevel directory of the ``brig`` repository,
+and make sure you've selected that environment. For example::
+
+   $ python3 -m venv benv
+
+or if using ``pyenv``::
+
+   $ pyenv exec python -m venv benv
+
+
+Populate the Virtual Environment
+================================
+
+Populate the virtual environment. Some tools like PyCharm will want this.
+Note that this virtual environment is used *only* for debugging and testing::
+
+  $ poetry install
+
+
+Execute Commands in This Function's Folder
+==========================================
+
+Select this subfolder of the ``brig`` repository::
+
+   $ cd functions/<function-name>
+
+If the function is part of an API, that will be::
+
+   $ cd apis/<api-name>/functions/<function-name>
+
+
+Running The Tests
+=================
+
+From within the function folder, use ``brig-test`` to do testing::
+
+   $ brig-test
+
+This command will freshly build requirements from ``requirements.txt``
+in the current folder, placing them along with source file (from the ``src/``
+subfolder) and putting them in the ``stg/`` subfolder. These will be run there.
+
+The build will also be zipped into ``bld/`` and a link will be created
+from ``bld/staged`` to the zip being tested. Note that this works
+by calling::
+
+   $ brig-build --test-only
+
+Note that ``brig-build`` always runs tests first, but if given this
+``--test-only`` argument, it will stop wiht that.  If the argument is omitted,
+thne if testing succeeds, ``brig-build`` will also link``bld/current`` to
+the zip that was created. If the test fails, or if ``--test-only`` is given,
+then that link won't be created. (Also, if ``bld/current`` *is* updated,
+the previous target of ``bld/current`` will be available through the link
+``bld/previous``.

--- a/functions/4dn-status/README.rst
+++ b/functions/4dn-status/README.rst
@@ -1,0 +1,337 @@
+==========
+4dn-status
+==========
+
+If you have a function that is not part of an API, make a folder for it here.
+
+General Information about brig functions
+========================================
+
+For more details, see `README.rst <../../README.rst>`_ in the ``brig`` repository root folder.
+
+For information specifically about testing, see `TESTING.rst <../TESTING.rst>`_
+in the same folder.
+
+Staging and Deploying this interface
+====================================
+
+This interface is intended for upload to the 4dn-status lambda function.
+
+There is also a 4dn-status-staged function you can use for testing.
+
+4dn-status Data storage
+=======================
+
+Location of 4dn-status data
+---------------------------
+
+Storage for the ``/4dn-status`` endpoint is in S3 at:
+
+   s3://4dn-dcic-publicly-served/4dn-status/calendar.json
+
+Storage for the ``/4dn-status-staged`` endpoint is in S3 at:
+
+   s3://4dn-dcic-publicly-served/4dn-status/calendar-staged.json
+
+Format of a calendar.json file
+------------------------------
+
+The json data file for this endpoint contains a dictionary that can contain
+data of the following kind. See the functionality description for information
+on how this data is used.
+
+* ``"calendar"`` (required)
+
+  The calendar is a possibly empty list of
+  ``<calendar-event>`` objects.
+
+A ``<calendar-event>`` can have any of these fields:
+
+* ``"name"`` (required)
+
+  The name is a ``<string>`` that names the event.
+
+* ``"description"``
+
+  The description is a ``<string>`` that describes the event, usually in more detail
+  than the name.
+
+* ``"priority"`` (optional, default ``"green"``)
+
+  A ``<priority-string>`` that specifies that the banner
+  should have at least this priority if this event is displayed.
+
+* ``"start_time"`` (optional, default ``null``)
+
+  The start time is a ``<datetime-string>`` (or ``null``)
+  specifying when the calendar event starts.
+  If null or unspecified, it defaults to the beginning of time.
+
+* ``"end_time"`` (optional, default ``null``)
+
+  The end time is a ``<datetime-string>`` (or ``null``)
+  specifying when the calendar event starts.
+  If null or unspecified, it defaults to the end of time.
+
+* ``"lead_time"`` (optional, default ``null``)
+
+  The lead time is ``<relative-time-spec>`` that specifies an additional bit of
+  time before a given event where the notice of the event should appear even though
+  the event has not begun.
+
+* ``"affects"`` (optional, default ``null``)
+
+  A ``<affects-spec>`` describing the set of affected servers.
+  If omitted, all environments are assumed affected.
+
+The ``<affects-spec>`` has these elements:
+
+* ``"name"``
+
+  The name is a summary of affected systems for the situation where
+  it's only certain systems. e.g., "CGAP Dev Systems"
+
+* ``"environments"`` (optional, default a list of all valid environments)
+
+  A list of the systems that this outage applies to.
+
+  For Fourfront staging or production, ``fourfront-webprod`` is used in place
+  of an ordinary name, since the blue/green distinction is problematic. It does
+  not matter that we don't call it that name any more as an environment. (This
+  is a formal token that is chosen using ``dcicutils.env_utils.get_bucket_env``.)
+
+  For CGAP staging or production, ``fourfront-cgap`` is used for similar reasons.
+  Of course, there is no CGAP staging right now, but there could be in the future.
+
+Type Definitions
+~~~~~~~~~~~~~~~~
+
+* **<datetime-string>**
+
+  A ``<datetime-string>`` is a ``<string>``
+  of specialized form, specifically the
+  format ``YYYY-mm-dd hh:mm:ss``
+  and will be assumed to be relative to the reference time frame of the system,
+  (which is ``US/Eastern`` for hms-based systems).
+
+  It is also possible to specify
+  a specific timezone, as in ``YYYY-mm-dd hh:mm:ss-nnnn`` or
+  ``YYYY-mm-dd hh:mm:ss+nnnn`` where ``nnnn`` is an
+  ``hhmm`` specification of a timezone offset to be added or subtracted to ``UTC``.
+  This notation is *not* recommended because it will not respect daylight time.
+  Using the reference time *will* use daylight time as appropriate.
+
+* **<priority-string>**
+
+  A ``<priority-string>`` is a ``<string>`` of specialized form.
+  These are strings that represent CSS styles when using
+  an HTML response.
+
+  * ``"red"`` - Events that are outages.
+  * ``"yellow"`` - Events that involve variable or risky behavior.
+  * ``"green"`` - Events that are not disruptive or a notice about a lack of events.
+
+  If multiple bgstyles are in play, the one with the
+  highest priority will take precedence, using priority
+  from lowest (``"green"``) to highest (``"red"``).
+
+* **<relative-time-spec>**
+
+  A ``<relative-time-spec>`` is either a number of seconds
+  or else a dictionary with fields that specify the number of seconds in parts
+  the way people talk about them. For example, 36 hours could be referred to as
+  any of these:
+
+  * ``{"days" 1, "hours": 12}``
+  * ``{"days": 1.5}``
+  * ``{"hours": 36}``
+  * ``{"hours": 35, "minutes": 59, "seconds" 60}``
+
+  Normally one would not use obscure breakdowns like the last one, of course.
+  In general, the idea is to allow relative times to be referred to in a way
+  intelligible to the human eye.
+
+  Possible fields if the dictionary form is used are:
+
+  * ``"days"``
+  * ``"hours"``
+  * ``"minutes"``
+  * ``"seconds"``
+
+* **<string>**
+
+  A JSON string.
+
+
+4dn-status Functionality
+========================
+
+The endpoint ``/4dn-status`` (and ``/4dn-status-staging``) returns status information
+for a particular affected environment.
+
+Query Parameters
+----------------
+
+* **application**
+
+  The application specified should be one of ``fourfront`` or ``cgap``.
+  Using this bypasses any heuristics related to the name of a referring URL.
+
+* **environment**
+
+  The environment can be something like ``fourfront-mastertest`` or another so-called "ffenv"
+  name, to include the name of a CGAP env such as ``fourfront-cgapdev``. This is more specific
+  than using ``application`` so takes priority. There is no need to supply both. However, the
+  UI might not be aware of the exact environment name.  If supplying this explicitly, use
+  ``fourfront-webprod`` for either staging (``staging.4dnucleome.org``)
+  or production (``data.4dnucleome.org``). Use ``fourfront-cgap`` for production CGAP
+  (``cgap.hms.harvard.edu``).
+
+Debugging parameters **not to be used in production**:
+
+* **debug**
+
+  Causes the response to contain debugging information (when ``format=json`` is also used).
+
+* **format**
+
+  When used with ``format=json`` the result is JSON rather than HTML.
+
+* **now**
+
+  Can be used to specify a reference time, rather than the current time, for interactive testing.
+  The time should be in the format of a ``<datetime-string>``.
+
+Format of endpoint call result
+------------------------------
+
+The call will return data that is similar to what's in the calendar.json file, but
+filtered to contain only relevant entries matching:
+
+* The time at which the call is made.
+
+  For debugging only, the time can be overridden with ``now=``
+  as a query parameter.
+
+* The ``environment=`` parameter given. (See the ``affects`` specification in the
+  calendar.json file.
+
+  If no ``environment=`` is given, then if ``application=`` is given, the environment
+  ``fourfront-webprod`` is used for ``fourfront`` and ``fourfront-cgap`` is given for
+  ``cgap``.
+
+
+  If neither ``environment=`` or ``application=`` is given, then if the referer is
+  a CGAP url, ``application=cgap`` will be assumed, and otherwise ``application=fourfront``
+  will be assumed.
+
+The following additional fields may appear and have the following meaning:
+
+* ``"message"``
+
+  If a ``"message"`` is present, it is an error message to be used instead of the
+  calendar data.
+
+* ``"problems"``
+
+  If ``"problems"`` is given, it is a list of detailed information about errors that
+  happened. It is for debugging only and is not intended to be presented to users.
+
+* ``"priority"``
+
+  If a ``"priority"`` appears, it will be a ``<priority-string>``.
+  This token may be useful in picking a display color for the data.
+
+  Individual calendar entries will have possibly-differing priorities, but
+  if the overall calendar priority is ``"green"``, it may be useful to just omit
+  display of the calendar entirely, as this indicates normal system operation
+  and not a piece of priority information.
+
+CGAP vs Fourfront
+-----------------
+
+It is recommended that any call from the CGAP application use the query argument
+``application=cgap`` and any call from Fourfront use the query argument ``application=fourfront``.
+This will avoid any confusion if the ``referer`` header is missing or mal-formed.
+
+By default, the host is the primary server host, so that the production application
+doesn't have to say. That is, ``/4dn-status`` for CGAP any CGAP environment
+will look at the ``referer`` header, see that it is a cgap host,
+and will return information about ``cgap.hms.harvard.edu`` as if
+``/4dn-status?environment=fourfront-cgap`` had been supplied, and similarly for
+any non-CGAP host will return information as if
+``/4dn-status?environment=fourfront-webprod`` had been supplied.
+
+.. note::
+
+   See explanation of ``<affects-spec>`` above for more information about this choice
+   of environment name.
+
+Examples
+========
+
+Given a calendar file like::
+
+   {
+     "calendar: []
+   }
+
+Browsing to::
+
+    /4dn-status?application=cgap
+
+Will might show an HTML page with this essential content::
+
+    ===== [CGAP helix logo] CGAP Status ===== <- green banner
+    No Scheduled Events
+    All Systems (now to the foreseeable future)
+    No known problems. No disruptions planned.
+
+Given::
+
+    /4dn-status?application=cgap&format=json
+
+the result will be::
+
+   {
+     "priority": "green",
+     "calendar": []
+   }
+
+This same result might happen if the calendar contains events in the past or
+in the too-far future::
+
+   {
+     "calendar: [{
+       "start_time": "2050-01-01 00:00:00",
+       "end_time": "2050-01-02 00:00:00",
+       "lead_time": {"weeks": 1},
+       "name": "CGAP Long-term Maintenance",
+       "description": "Background testing that CGAP's part have not rusted out from old age.",
+       "priority": "yellow",
+       "affects": {"environments": ["fourfront-cgap"], "name": "CGAP"}
+     }]
+   }
+
+A week before the specified start time, however, the result will start to be::
+
+   {
+     "priority": "yellow",
+     "calendar: [{
+       "start_time": "2050-01-01 00:00:00",
+       "end_time": "2050-01-02 00:00:00",
+       "lead_time": {"weeks": 1},
+       "name": "CGAP Long-term Maintenance",
+       "description": "Background testing that CGAP's part have not rusted out from old age.",
+       "priority": "yellow",
+       "affects": {"environments": ["fourfront-cgap"], "name": "CGAP"}
+     }]
+   }
+
+with corresponding HTML that displays as something like::
+
+   ===== [4DN sphere logo] CGAP Status ===== <- yellow banner
+   CGAP Long-Term Maintenance
+   CGAP (2050-01-01 00:00:00 to 2050-01-02 00:00:00)
+   Background testing that CGAP's part have not rusted out from old age.
+

--- a/functions/4dn-status/src/lambda_function.py
+++ b/functions/4dn-status/src/lambda_function.py
@@ -1,17 +1,42 @@
+import datetime
 import html
 import io
 import json
 import requests
 
-from dcicutils.misc_utils import hms_now, as_datetime, in_datetime_interval, ignored, full_class_name
+from dcicutils.misc_utils import (
+    hms_now, as_datetime, in_datetime_interval, ignored, full_class_name, as_ref_datetime, as_seconds,
+)
 from dcicutils.env_utils import (
     classify_server_url, FF_PROD_BUCKET_ENV, CGAP_PROD_BUCKET_ENV, get_bucket_env, is_cgap_env,
 )
 
 
-DEFAULT_COLOR = "#ccffcc"
+PRIORITY_RED = 'red'
+PRIORITY_ORANGE = 'orange'
+PRIORITY_YELLOW = 'yellow'
+PRIORITY_GREEN = 'green'
 
-DEFAULT_EVENT = {
+DEFAULT_PRIORITY = PRIORITY_GREEN
+
+ALL_PRIORITY_NAMES = [PRIORITY_GREEN, PRIORITY_YELLOW, PRIORITY_ORANGE, PRIORITY_RED]
+
+PRIORITY_ORANGE_VALUE = ALL_PRIORITY_NAMES.index(PRIORITY_ORANGE)
+
+
+def priority_value(priority):
+    try:
+        return ALL_PRIORITY_NAMES.index(priority)
+    except Exception:
+        return PRIORITY_ORANGE_VALUE
+
+
+def merge_priorities(*priorities):
+    priority = max(map(priority_value, priorities))
+    return ALL_PRIORITY_NAMES[priority]
+
+
+NULL_EVENT = {
     "name": "No Scheduled Events",
     "start_time": None,
     "end_time": None,
@@ -22,14 +47,11 @@ DEFAULT_EVENT = {
     }
 }
 
-   
-DEFAULT_DATA = {
-    "bgcolor": DEFAULT_COLOR,
-    "calendar": [
-        DEFAULT_EVENT,
-    ]
-}
+DEFAULT_DATA_EVENTS = []
 
+DEFAULT_DATA = {
+    "calendar": DEFAULT_DATA_EVENTS,
+}
 
 CALENDAR_DATA_URL_PRD = "https://4dn-dcic-publicly-served.s3.amazonaws.com/4dn-status/calendar.json"
 CALENDAR_DATA_URL_STG = "https://4dn-dcic-publicly-served.s3.amazonaws.com/4dn-status/calendar-staged.json"
@@ -37,9 +59,9 @@ CALENDAR_DATA_URL_STG = "https://4dn-dcic-publicly-served.s3.amazonaws.com/4dn-s
 PRD_ENDPOINT_PATH = '/4dn-status'
 STG_ENDPOINT_PATH = '/4dn-status-staged'
 
-
 CALENDAR_MISSING_MESSAGE = "Calendar data is unavailable."
-CALENDAR_MISSING_COLOR = "#ffdddd"
+CALENDAR_MISSING_PRIORITY = PRIORITY_RED
+
 
 def get_calendar_data(staged=False):
     url = CALENDAR_DATA_URL_STG if staged else CALENDAR_DATA_URL_PRD
@@ -51,14 +73,12 @@ def get_calendar_data(staged=False):
         return result or DEFAULT_DATA
     except Exception as e:
         data = {
+            "priority": CALENDAR_MISSING_PRIORITY,
             "calendar": [],
-            "problems": [
-                {
-                    "message": "%s: %s" % (full_class_name(e), e)
-                }
-            ],
             "message": CALENDAR_MISSING_MESSAGE,
-            "bgcolor": CALENDAR_MISSING_COLOR,
+            "problems": [{
+                "message": "%s: %s" % (full_class_name(e), e)
+            }],
         }
         return data
 
@@ -76,33 +96,36 @@ def convert_to_html(data, environment):
         logo_url = FF_LOGO_URL
         logo_url_alt = "4DN sphere logo"
         page_name = "Fourfront Status"
-    calendar_events = data.get('calendar', [])
-    bgcolor = data.get('bgcolor', 'white')
-    message = data.get('message')
+
+    message = data.get("message")
+    calendar_events = data.get('calendar')
+    if not calendar_events and not message:
+        # When there's no error message to shown, supply a default event if nothing else to show.
+        calendar_events = [NULL_EVENT]
+    priority = data.get('priority') or DEFAULT_PRIORITY
     event_str = io.StringIO()
     sections_used = []
-    if not message:
-        for i, event in enumerate(calendar_events, start=1):
-            # print("calendar_event=", calendar_event, "i=", i)
-            event_name = event.get('name') or "Event %s" % i
-            affects = event.get('affects') or {}
-            affects_name = affects.get('name') or "All Systems"
-            # affects_envs = affects.get('environments') or []
-            section = io.StringIO()
-            section.write('<dt class="calendar-event">%s</dt>\n' % html.escape(event_name))
-            section.write("<dd>\n")
-            section.write('<p><span class="who">%s</span>' % html.escape(affects_name))
-            section.write(' <span class="when">(%s to %s)</span></p>\n'
-                          % (html.escape(event.get('start_time') or "now"),
-                             html.escape(event.get('end_time') or "the foreseeable future")))
-            section.write('<p class="what">%s</p>\n' % (html.escape(event.get('message') or "To Be Determined")))
-            section.write("</dt>\n")
-            event_str.write(section.getvalue())
-            sections_used.append(i)
+    for i, event in enumerate(calendar_events, start=1):
+        # print("calendar_event=", calendar_event, "i=", i)
+        event_name = event.get('name') or "Event %s" % i
+        affects = event.get('affects') or {}
+        affects_name = affects.get('name') or ""
+        # affects_envs = affects.get('environments') or []
+        section = io.StringIO()
+        section.write('<dt class="calendar-event">%s</dt>\n' % html.escape(event_name))
+        section.write("<dd>\n")
+        section.write('<p><span class="who">%s</span>' % html.escape(affects_name))
+        section.write(' <span class="when">(%s to %s)</span></p>\n'
+                      % (html.escape(event.get('start_time') or "now"),
+                         html.escape(event.get('end_time') or "the foreseeable future")))
+        section.write('<p class="what">%s</p>\n' % (html.escape(event.get("description") or "To Be Determined")))
+        section.write("</dt>\n")
+        event_str.write(section.getvalue())
+        sections_used.append(i)
     event_body = event_str.getvalue()
-    message = '<div class="message"><p>NOTE: ' + message + '</p></div>' if message else ''
+    message = '<div class="message bgcolor_orange"><p>NOTE: ' + html.escape(message) + '</p></div>' if message else ''
     substitutions = {
-        'BGCOLOR': bgcolor,
+        'PRIORITY': priority,
         'LOGO_URL': logo_url,
         'LOGO_URL_ALT': logo_url_alt,
         'PAGE_NAME': page_name,
@@ -116,7 +139,11 @@ def convert_to_html(data, environment):
   <title>4DN Status</title>
    <meta name="robots" content="noindex, nofollow" />
    <style><!--
-   .banner {padding-left: 30pt; background: <<BGCOLOR>>; padding-bottom: 10pt; padding-top: 10pt;}
+   .bgcolor_red {background: #ffdddd}
+   .bgcolor_orange {background: #ffeedd}
+   .bgcolor_yellow {background: #ffffdd}
+   .bgcolor_green {background: #ddffdd}
+   .banner {padding-left: 30pt; padding-bottom: 10pt; padding-top: 10pt;}
    .page-name {padding-left: 10pt; font-size: 30pt;}
    .logo {height: 100%; vertical-align: middle; height: 36pt;}
    .calendar {padding-left: 30pt;}
@@ -124,12 +151,12 @@ def convert_to_html(data, environment):
    .who {font-weight: bold; font-size: 16pt;}
    .when {font-weight: bold; font-size: 14pt;}
    .what {font-size: 12pt;}
-   div.message {margin-top: 5pt; padding-left: 30pt; border: 1pt red solid; width: 500pt; background: #ffeedd;}
+   div.message {margin-top: 5pt; padding-left: 30pt; border: 1pt red solid; width: 500pt;}
    div.message p {font-weight: bold;}
   --></style>
  </head>
  <body>
-  <div class="banner" id="banner">
+  <div class="banner bgcolor_<<PRIORITY>>" id="banner">
    <table>
     <tr>
      <td valign="middle">
@@ -150,13 +177,16 @@ def convert_to_html(data, environment):
     return body
 
 
-def filter_data(data, environment, debug=False, now=None):
+def filter_data(data, environment, *, debug=False, now=None):
     calendar_events = data.get("calendar") or []
-    bgcolor = data.get("bgcolor") or "#dddddd"
+    priority = DEFAULT_PRIORITY
+    # "message" and "problems" are not intended to be used in ordinary calendar.json file.
+    # Instead they're used for error handling if the calendar is not available
+    # and must be propagated so the end user will understand why data was unavailable.
     message = data.get("message")
+    problems = data.get("problems", [])
     filtered_calendar_events = []
     filter_now = as_datetime(now, raise_error=False) or hms_now()
-    problems = data.get("problems", [])
     seen = []
     removed = []
     for event in calendar_events:
@@ -166,9 +196,21 @@ def filter_data(data, environment, debug=False, now=None):
             end_time = event.get('end_time', None)
             affected_envs = (event.get('affects') or {}).get('environments')
             if affected_envs is None or environment in map(canonicalize_environment, affected_envs):
-                # TODO: It's possible the datetime will be ill-formed, in which case an error will be raised
+                if start_time:
+                    start_time = as_ref_datetime(start_time)
+                    lead_time = event.get('lead_time') or {}
+                    if lead_time:
+                        if isinstance(lead_time, dict):
+                            # "lead_time": {"hours": 1, "minutes": 30}
+                            lead_seconds = as_seconds(**lead_time)
+                        else:
+                            # "lead_time": 5400
+                            lead_seconds = lead_time
+                        # This operation affects only the filtering, but not the display.
+                        start_time -= datetime.timedelta(seconds=lead_seconds)
                 if in_datetime_interval(filter_now, start=start_time, end=end_time):
                     filtered_calendar_events.append(event)
+                    priority = merge_priorities(priority, event.get("priority"))
                 else:
                     removed.append(event)
         except Exception as e:
@@ -183,12 +225,7 @@ def filter_data(data, environment, debug=False, now=None):
         result["seen"] = seen
         result["defaulted"] = False
         result["removed"] = removed
-    if not filtered_calendar_events and not message:
-        if debug:
-            result["defaulted"] = True
-        bgcolor = DEFAULT_COLOR
-        filtered_calendar_events.append(DEFAULT_EVENT)
-    result["bgcolor"] = bgcolor
+    result["priority"] = priority
     if message:
         result["message"] = message
     result["calendar"] = filtered_calendar_events

--- a/functions/4dn-status/src/test_lambda_function.py
+++ b/functions/4dn-status/src/test_lambda_function.py
@@ -583,8 +583,8 @@ class TestInternals(ApiTestCaseBase):
 
     def test_resolve_environment(self):
 
-        def test(*, expected, referer=None, application=None, environment=None):
-            self.assertEqual(resolve_environment(referer=referer, application=application, environment=environment),
+        def test(*, expected, host=None, referer=None, application=None, environment=None):
+            self.assertEqual(resolve_environment(host=host, referer=referer, application=application, environment=environment),
                              expected)
 
         self.debug_print("Testing for no context.")
@@ -620,7 +620,17 @@ class TestInternals(ApiTestCaseBase):
             test(application=application, referer=CGAPTEST_SERVER, expected='fourfront-cgaptest')
             test(application=application, referer=CGAP_PRD_SERVER, expected='fourfront-cgap')
 
-        # The application can be specified and will take effect if there is no environment or referer.
+        # The host may resolve things if there is no referer
+
+        for application in ('cgap', 'fourfront', None):
+
+            self.debug_print("Testing referers with application=", application)
+
+            test(application=application, host='status.data.4dnucleome.org', expected='fourfront-webprod')
+            test(application=application, host='status.staging.4dnucleome.org', expected='fourfront-webprod')
+            test(application=application, host='status.cgap.hms.harvard.edu', expected='fourfront-cgap')
+
+        # The application can be specified and will take effect if there is no environment or referer or host.
         self.debug_print("Testing application.", application)
 
         test(application='cgap', expected='fourfront-cgap')

--- a/functions/4dn-status/src/test_lambda_function.py
+++ b/functions/4dn-status/src/test_lambda_function.py
@@ -8,8 +8,10 @@ from dcicutils.qa_utils import ControlledTime
 from unittest import mock
 from . import lambda_function as lambda_function_module
 from .lambda_function import (
-    lambda_handler, DEFAULT_EVENT, DEFAULT_DATA, get_calendar_data, CALENDAR_DATA_URL_PRD, resolve_environment,
-    CALENDAR_MISSING_COLOR, CALENDAR_MISSING_MESSAGE,
+    lambda_handler, DEFAULT_DATA, DEFAULT_DATA_EVENTS,
+    get_calendar_data, CALENDAR_DATA_URL_PRD, resolve_environment,
+    CALENDAR_MISSING_PRIORITY, CALENDAR_MISSING_MESSAGE,
+    PRIORITY_RED, PRIORITY_ORANGE, PRIORITY_GREEN, PRIORITY_YELLOW, merge_priorities,
 )
 
 
@@ -62,7 +64,7 @@ SAMPLE_FF_SYSTEM_UPGRADE = {
     "name": "Fourfront System Upgrades",
     "start_time": START_SAMPLE_BLOCK1,
     "end_time": END_SAMPLE_BLOCK1,
-    "message": "Systems may be unavailable.",
+    "description": "Systems may be unavailable.",
     "affects": {
         "name": "All Fourfront Systems",
         "environments": [
@@ -79,7 +81,7 @@ SAMPLE_FF_SUMMER_NOTICE = {
     "name": "Fourfront Mastertest Summer Shutdown",
     "start_time": START_SAMPLE_BLOCK2,
     "end_time": END_SAMPLE_BLOCK2,
-    "message": "We're all at the beach. Happy Summer!",
+    "description": "We're all at the beach. Happy Summer!",
     "affects": {
         "name": "Fourfront Mastertest Users",
         "environments": [
@@ -92,7 +94,7 @@ SAMPLE_CG_SUMMER_NOTICE = {
     "name": "CGAP Wolf Summer Shutdown",
     "start_time": START_SAMPLE_BLOCK2,
     "end_time": END_SAMPLE_BLOCK2,
-    "message": "We're all at the beach. Happy Summer!",
+    "description": "We're all at the beach. Happy Summer!",
     "affects": {
         "name": "CGAP Wolf Users",
         "environments": [
@@ -104,7 +106,7 @@ SAMPLE_CG_SUMMER_NOTICE = {
 SAMPLE_EVENTS = [SAMPLE_FF_SYSTEM_UPGRADE, SAMPLE_FF_SUMMER_NOTICE, SAMPLE_CG_SUMMER_NOTICE]
 
 SAMPLE_DATA = {
-    "bgcolor": "#ffcccc",
+    "priority": PRIORITY_RED,
     "calendar": SAMPLE_EVENTS
 }
 
@@ -229,71 +231,71 @@ class TestApi(ApiTestCase):
     def test_json_for_regular_hosts_various_ff(self):
         application = 'fourfront'
         scenarios = [
-            (1, None, BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (1, None, BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
             (2, None, DURING_SAMPLE_BLOCK1, [SAMPLE_FF_SYSTEM_UPGRADE]),
-            (3, None, AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (3, None, AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
-            (11, 'fourfront-webprod', BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (11, 'fourfront-webprod', BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
             (22, 'fourfront-webprod', DURING_SAMPLE_BLOCK1, [SAMPLE_FF_SYSTEM_UPGRADE]),
-            (33, 'fourfront-webprod', AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (33, 'fourfront-webprod', AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
             # Synonym for fourfront-webprod
-            (1011, 'fourfront-webprod2', BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (1011, 'fourfront-webprod2', BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
             (1033, 'fourfront-webprod2', DURING_SAMPLE_BLOCK1, [SAMPLE_FF_SYSTEM_UPGRADE]),
-            (1033, 'fourfront-webprod2', AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (1033, 'fourfront-webprod2', AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
             # Synonym for fourfront-webprod
-            (2011, 'fourfront-green', BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (2011, 'fourfront-green', BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
             (2022, 'fourfront-green', DURING_SAMPLE_BLOCK1, [SAMPLE_FF_SYSTEM_UPGRADE]),
-            (3033, 'fourfront-green', AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (3033, 'fourfront-green', AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
-            (111, 'fourfront-mastertest', BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (111, 'fourfront-mastertest', BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
             (222, 'fourfront-mastertest', DURING_SAMPLE_BLOCK1, [SAMPLE_FF_SYSTEM_UPGRADE]),
-            (333, 'fourfront-mastertest', AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (333, 'fourfront-mastertest', AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
-            (1111, 'fourfront-cgap', BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
-            (2222, 'fourfront-cgap', DURING_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
-            (3333, 'fourfront-cgap', AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (1111, 'fourfront-cgap', BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
+            (2222, 'fourfront-cgap', DURING_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
+            (3333, 'fourfront-cgap', AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
-            (4, None, BEFORE_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (5, None, DURING_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (6, None, AFTER_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (4, None, BEFORE_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (5, None, DURING_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (6, None, AFTER_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
 
-            (44, 'fourfront-webprod', BEFORE_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (55, 'fourfront-webprod', DURING_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (66, 'fourfront-webprod', AFTER_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (44, 'fourfront-webprod', BEFORE_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (55, 'fourfront-webprod', DURING_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (66, 'fourfront-webprod', AFTER_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
 
-            (444, 'fourfront-mastertest', BEFORE_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (444, 'fourfront-mastertest', BEFORE_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
             (555, 'fourfront-mastertest', DURING_SAMPLE_BLOCK2, [SAMPLE_FF_SUMMER_NOTICE]),
-            (666, 'fourfront-mastertest', AFTER_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (666, 'fourfront-mastertest', AFTER_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
 
-            (4444, 'fourfront-cgap', BEFORE_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (5555, 'fourfront-cgap', DURING_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (6666, 'fourfront-cgap', AFTER_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (4444, 'fourfront-cgap', BEFORE_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (5555, 'fourfront-cgap', DURING_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (6666, 'fourfront-cgap', AFTER_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
 
-            (44444, 'fourfront-cgapwolf', BEFORE_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (44444, 'fourfront-cgapwolf', BEFORE_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
             (55555, 'fourfront-cgapwolf', DURING_SAMPLE_BLOCK2, [SAMPLE_CG_SUMMER_NOTICE]),
-            (66666, 'fourfront-cgapwolf', AFTER_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (66666, 'fourfront-cgapwolf', AFTER_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
 
-            (7, None, BEFORE_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
-            (8, None, DURING_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
-            (9, None, AFTER_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
+            (7, None, BEFORE_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
+            (8, None, DURING_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
+            (9, None, AFTER_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
 
-            (77, 'fourfront-webprod', BEFORE_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
-            (88, 'fourfront-webprod', DURING_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
-            (99, 'fourfront-webprod', AFTER_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
+            (77, 'fourfront-webprod', BEFORE_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
+            (88, 'fourfront-webprod', DURING_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
+            (99, 'fourfront-webprod', AFTER_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
 
-            (777, 'fourfront-mastertest', BEFORE_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
+            (777, 'fourfront-mastertest', BEFORE_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
             (888, 'fourfront-mastertest', DURING_SAMPLE_BLOCK3, [SAMPLE_FF_SUMMER_NOTICE]),
-            (999, 'fourfront-mastertest', AFTER_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
+            (999, 'fourfront-mastertest', AFTER_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
 
-            (7777, 'fourfront-cgap', BEFORE_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
-            (8888, 'fourfront-cgap', DURING_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
-            (9999, 'fourfront-cgap', AFTER_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
+            (7777, 'fourfront-cgap', BEFORE_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
+            (8888, 'fourfront-cgap', DURING_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
+            (9999, 'fourfront-cgap', AFTER_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
 
-            (77777, 'fourfront-cgapwolf', BEFORE_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
+            (77777, 'fourfront-cgapwolf', BEFORE_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
             (88888, 'fourfront-cgapwolf', DURING_SAMPLE_BLOCK3, [SAMPLE_CG_SUMMER_NOTICE]),
-            (99999, 'fourfront-cgapwolf', AFTER_SAMPLE_BLOCK3, [DEFAULT_EVENT]),
+            (99999, 'fourfront-cgapwolf', AFTER_SAMPLE_BLOCK3, DEFAULT_DATA_EVENTS),
 
         ]
         for n, environment, base_time, expected_events in scenarios:
@@ -311,47 +313,47 @@ class TestApi(ApiTestCase):
     def test_json_for_regular_hosts_various_cgap(self):
         application = 'cgap'
         scenarios = [
-            (1, None, BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
-            (2, None, DURING_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
-            (3, None, AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (1, None, BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
+            (2, None, DURING_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
+            (3, None, AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
-            (11, 'fourfront-cgap', BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
-            (22, 'fourfront-cgap', DURING_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
-            (33, 'fourfront-cgap', AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (11, 'fourfront-cgap', BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
+            (22, 'fourfront-cgap', DURING_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
+            (33, 'fourfront-cgap', AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
-            (111, 'fourfront-cgapwolf', BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
-            (222, 'fourfront-cgapwolf', DURING_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
-            (333, 'fourfront-cgapwolf', AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (111, 'fourfront-cgapwolf', BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
+            (222, 'fourfront-cgapwolf', DURING_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
+            (333, 'fourfront-cgapwolf', AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
-            (1111, 'fourfront-webprod', BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (1111, 'fourfront-webprod', BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
             (2222, 'fourfront-webprod', DURING_SAMPLE_BLOCK1, [SAMPLE_FF_SYSTEM_UPGRADE]),
-            (3333, 'fourfront-webprod', AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (3333, 'fourfront-webprod', AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
             # Synonym for fourfront-webprod
-            (101111, 'fourfront-webprod2', BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (101111, 'fourfront-webprod2', BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
             (102222, 'fourfront-webprod2', DURING_SAMPLE_BLOCK1, [SAMPLE_FF_SYSTEM_UPGRADE]),
-            (103333, 'fourfront-webprod2', AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (103333, 'fourfront-webprod2', AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
             # Synonym for fourfront-webprod
-            (201111, 'fourfront-green', BEFORE_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (201111, 'fourfront-green', BEFORE_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
             (202222, 'fourfront-green', DURING_SAMPLE_BLOCK1, [SAMPLE_FF_SYSTEM_UPGRADE]),
-            (203333, 'fourfront-green', AFTER_SAMPLE_BLOCK1, [DEFAULT_EVENT]),
+            (203333, 'fourfront-green', AFTER_SAMPLE_BLOCK1, DEFAULT_DATA_EVENTS),
 
-            (4, None, BEFORE_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (5, None, DURING_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (6, None, AFTER_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (4, None, BEFORE_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (5, None, DURING_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (6, None, AFTER_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
 
-            (44, 'fourfront-cgap', BEFORE_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (55, 'fourfront-cgap', DURING_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (66, 'fourfront-cgap', AFTER_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (44, 'fourfront-cgap', BEFORE_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (55, 'fourfront-cgap', DURING_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (66, 'fourfront-cgap', AFTER_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
 
-            (444, 'fourfront-cgapwolf', BEFORE_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (444, 'fourfront-cgapwolf', BEFORE_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
             (555, 'fourfront-cgapwolf', DURING_SAMPLE_BLOCK2, [SAMPLE_CG_SUMMER_NOTICE]),
-            (666, 'fourfront-cgapwolf', AFTER_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (666, 'fourfront-cgapwolf', AFTER_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
 
-            (4444, 'fourfront-webprod', BEFORE_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (5555, 'fourfront-webprod', DURING_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
-            (6666, 'fourfront-webprod', AFTER_SAMPLE_BLOCK2, [DEFAULT_EVENT]),
+            (4444, 'fourfront-webprod', BEFORE_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (5555, 'fourfront-webprod', DURING_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
+            (6666, 'fourfront-webprod', AFTER_SAMPLE_BLOCK2, DEFAULT_DATA_EVENTS),
         ]
         for n, environment, base_time, expected_events in scenarios:
             self.debug_print("n=", n)
@@ -405,6 +407,38 @@ class TestApi(ApiTestCase):
 
 class TestInternals(ApiTestCaseBase):
 
+    def test_merge_bgstyles(self):
+
+        assert merge_priorities("abc", PRIORITY_RED) == "red"
+        assert merge_priorities(PRIORITY_RED, "abc") == "red"
+        assert merge_priorities("xyz", PRIORITY_RED) == "red"
+        assert merge_priorities(PRIORITY_RED, "xyz") == "red"
+
+        assert merge_priorities("abc", PRIORITY_GREEN) == "orange"
+        assert merge_priorities(PRIORITY_GREEN, "abc") == "orange"
+        assert merge_priorities("xyz", PRIORITY_GREEN) == "orange"
+        assert merge_priorities(PRIORITY_GREEN, "xyz") == "orange"
+
+        assert merge_priorities(PRIORITY_RED, PRIORITY_RED) == PRIORITY_RED
+        assert merge_priorities(PRIORITY_RED, PRIORITY_ORANGE) == PRIORITY_RED
+        assert merge_priorities(PRIORITY_RED, PRIORITY_YELLOW) == PRIORITY_RED
+        assert merge_priorities(PRIORITY_RED, PRIORITY_GREEN) == PRIORITY_RED
+
+        assert merge_priorities(PRIORITY_ORANGE, PRIORITY_RED) == PRIORITY_RED
+        assert merge_priorities(PRIORITY_ORANGE, PRIORITY_ORANGE) == PRIORITY_ORANGE
+        assert merge_priorities(PRIORITY_ORANGE, PRIORITY_YELLOW) == PRIORITY_ORANGE
+        assert merge_priorities(PRIORITY_ORANGE, PRIORITY_GREEN) == PRIORITY_ORANGE
+
+        assert merge_priorities(PRIORITY_YELLOW, PRIORITY_RED) == PRIORITY_RED
+        assert merge_priorities(PRIORITY_YELLOW, PRIORITY_ORANGE) == PRIORITY_ORANGE
+        assert merge_priorities(PRIORITY_YELLOW, PRIORITY_YELLOW) == PRIORITY_YELLOW
+        assert merge_priorities(PRIORITY_YELLOW, PRIORITY_GREEN) == PRIORITY_YELLOW
+
+        assert merge_priorities(PRIORITY_GREEN, PRIORITY_RED) == PRIORITY_RED
+        assert merge_priorities(PRIORITY_GREEN, PRIORITY_ORANGE) == PRIORITY_ORANGE
+        assert merge_priorities(PRIORITY_GREEN, PRIORITY_YELLOW) == PRIORITY_YELLOW
+        assert merge_priorities(PRIORITY_GREEN, PRIORITY_GREEN) == PRIORITY_GREEN
+
     def test_get_calendar_data(self):
 
         with mock.patch("requests.get") as mock_get:
@@ -432,7 +466,7 @@ class TestInternals(ApiTestCaseBase):
                 "calendar": [],
                 "problems": [{"message": "RuntimeError: Simulated HTTP request error."}],
                 "message": CALENDAR_MISSING_MESSAGE,
-                "bgcolor": CALENDAR_MISSING_COLOR,
+                "priority": CALENDAR_MISSING_PRIORITY,
             }
             self.assertEqual(get_calendar_data(), expected_data)
 
@@ -441,7 +475,7 @@ class TestInternals(ApiTestCaseBase):
                 "calendar": [],
                 "problems": [{"message": "RuntimeError: Some sort of error happened."}],
                 "message": CALENDAR_MISSING_MESSAGE,
-                "bgcolor": CALENDAR_MISSING_COLOR,
+                "priority": CALENDAR_MISSING_PRIORITY,
             }
             self.assertEqual(get_calendar_data(), expected_data)
 

--- a/functions/README.rst
+++ b/functions/README.rst
@@ -5,3 +5,6 @@ Functions
 If you have a function that is not part of an API, make a folder for it here.
 
 For more details, see `README.rst <../README.rst>`_ in the parent folder.
+
+For information specifically about testing, see `TESTING.rst <../TESTING.rst>`_
+in the same folder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "brig"
-version = "0.2"
+version = "0.3.0"
 description = "A psuedo-library wrapper for debugging lambda functionality."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
I added documentation for the 4dn-status protocol.

In doing this, I made some name changes to the data it uses so that the doc was easier to understand and the results were more meaningful.

* "bgcolor" is changed to "priority" and is a symbolic quality.
* In calendar events, I changed the field named "message" to "description"
* I implemented "lead_time" so that notices can show up in advance of when they're active.
* I fixed a bug where it only looked at referer and not host, so that now it can hopefully work on status.cgap.hms.harvard.edu and status.data.4dnucleome.org.
* 